### PR TITLE
Feature/custom table name support

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -236,18 +236,18 @@ func (a *Adapter) AddPolicy(sec string, ptype string, rule []string) error {
 // AddPolicies adds policy rules to the storage.
 func (a *Adapter) AddPolicies(sec string, ptype string, rules [][]string) error {
 	var lines []*CasbinRule
-	for _,rule := range rules{
+	for _, rule := range rules {
 		line := savePolicyLine(ptype, rule)
 		lines = append(lines, line)
 	}
-	
+
 	err := a.db.RunInTransaction(func(tx *pg.Tx) error {
 		_, err := tx.Model(&lines).
-		OnConflict("DO NOTHING").
-		Insert()
+			OnConflict("DO NOTHING").
+			Insert()
 		return err
 	})
-	
+
 	return err
 }
 
@@ -261,17 +261,17 @@ func (a *Adapter) RemovePolicy(sec string, ptype string, rule []string) error {
 // RemovePolicies removes policy rules from the storage.
 func (a *Adapter) RemovePolicies(sec string, ptype string, rules [][]string) error {
 	var lines []*CasbinRule
-	for _,rule := range rules{
+	for _, rule := range rules {
 		line := savePolicyLine(ptype, rule)
 		lines = append(lines, line)
 	}
 
 	err := a.db.RunInTransaction(func(tx *pg.Tx) error {
 		_, err := tx.Model(&lines).
-		Delete()
+			Delete()
 		return err
 	})
-	
+
 	return err
 }
 

--- a/adapter.go
+++ b/adapter.go
@@ -145,7 +145,7 @@ func (r *CasbinRule) String() string {
 func (a *Adapter) LoadPolicy(model model.Model) error {
 	var lines []*CasbinRule
 
-	if _, err := a.db.Query(&lines, `SELECT * FROM casbin_rules`); err != nil {
+	if err := a.db.Model(&lines).Select(); err != nil {
 		return err
 	}
 

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -120,17 +120,17 @@ func (s *AdapterTestSuite) TestAutoSave() {
 	// The policy has a new rule: {"alice", "data1", "write"}.
 	s.assertPolicy(
 		[][]string{
-		{"alice", "data1", "read"},
-		{"bob", "data2", "write"},
-		{"data2_admin", "data2", "read"},
-		{"data2_admin", "data2", "write"},
-		{"alice", "data1", "write"},
-		{"bob", "data2", "read"},
-		{"alice", "data2", "write"},
-		{"alice", "data2", "read"},
-		{"bob", "data1", "write"},
-		{"bob", "data1", "read"},
-	},
+			{"alice", "data1", "read"},
+			{"bob", "data2", "write"},
+			{"data2_admin", "data2", "read"},
+			{"data2_admin", "data2", "write"},
+			{"alice", "data1", "write"},
+			{"bob", "data2", "read"},
+			{"alice", "data2", "write"},
+			{"alice", "data2", "read"},
+			{"bob", "data1", "write"},
+			{"bob", "data1", "read"},
+		},
 		s.e.GetPolicy(),
 	)
 


### PR DESCRIPTION
This PR adds possibility to specify additional options when creating Adapter using existing DB connection. 

You can specify custom table name using `func WithTableName(tableName string) Option`

```go
db := pg.Connect(&pg.Options{
    Addr:     "localhost:5432",
    Database: "postgres",
    User:     "postgres",
    Password: "mysecretpassword",
})

a, err := pgadapter.NewAdapterByDB(db, pgadapter.WithTableName("permissions"))
if err != nil {
    fmt.Println(err)
}

```