### PR TITLE
feat: upgrade casbin to latest and add error to LoadPolicyLine()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ _testmain.go
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+vendor/

--- a/adapter.go
+++ b/adapter.go
@@ -199,7 +199,10 @@ func (a *Adapter) LoadPolicy(model model.Model) error {
 	}
 
 	for _, line := range lines {
-		persist.LoadPolicyLine(line.String(), model)
+		err := persist.LoadPolicyLine(line.String(), model)
+		if err != nil {
+			return err
+		}
 	}
 
 	a.filtered = false
@@ -423,7 +426,7 @@ func buildQuery(query *orm.Query, values []string) (*orm.Query, error) {
 	return query, nil
 }
 
-func (a *Adapter) loadFilteredPolicy(model model.Model, filter *Filter, handler func(string, model.Model)) error {
+func (a *Adapter) loadFilteredPolicy(model model.Model, filter *Filter, handler func(string, model.Model) error) error {
 	if filter.P != nil {
 		lines := []*CasbinRule{}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/casbin/casbin-pg-adapter
 go 1.14
 
 require (
-	github.com/casbin/casbin/v2 v2.36.1
+	github.com/casbin/casbin/v2 v2.55.1
 	github.com/go-pg/pg/v10 v10.9.1
 	github.com/mmcloughlin/meow v0.0.0-20181112033425-871e50784daf
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/casbin/casbin/v2 v2.36.1 h1:6b7PQuOEcNR4ZGvQcN82+E1o/n2KMNSUk+np9iryU8A=
 github.com/casbin/casbin/v2 v2.36.1/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
+github.com/casbin/casbin/v2 v2.55.1 h1:vaTAHSLkQfielg9UiHdIdvIVK/NAmMjBkDkrOM9iDqI=
+github.com/casbin/casbin/v2 v2.55.1/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-pg-adapter/issues/43

### Changes
- Upgraded casbin to `v2.55.1`.
- Updated function schema `LoadPolicyLine`.